### PR TITLE
Remove `setup-x86_64.exe` after it is used

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,7 @@ runs:
         SET CYGROOT=C:\cygwin64
         SET CYGCACHE=%CYGROOT%\var\cache\setup
         setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s %CYGMIRROR% -P ${{ inputs.PKGS_TO_INSTALL }}
+        rm -f setup-x86_64.exe
       env:
         CYGMIRROR: "http://mirror.easyname.at/cygwin"
       shell: cmd


### PR DESCRIPTION
Having this file still around is a minor annoyance in some other stuff that I'm doing, so if you don't mind I'd like it to be deleted after its use.