### PR TITLE
Remove steps changing the git configuration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,15 +8,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # This sets git to use Linux line endings. While GAP should allow
-    # Windows line endings in GAP files, we currently can't build GAP if the
-    # whole source has Windows line endings
-    - name: Set git to use LF
-      run: |
-        git config --global core.autocrlf false
-        git config --global core.eol lf
-      shell: powershell
-
     - name: Download cygwin
       run: |
         & cmd /c 'nslookup www.cygwin.com 2>&1'


### PR DESCRIPTION
- these are already done in the GAP CI.yml
- an action changing the git config is unexpected and can lead to bad problems
- packages which want to use this action may still need it; IMHO they should then
  add it to their CI.yml instead of relying on "magic" (we could tell them about it in
  the README of this action; but I hope it won't be necessary for most/all anyway)
- it comes to later if `actions/checkout` executed before it