### PR TITLE
Fix broken packages in action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All of the following inputs are optional.
 
 - `PKGS_TO_INSTALL`:
     - A comma separated list of packages to install
-    - default: `'wget,git,gcc,gcc-g++,gcc-core,m4,libgmp-devel,make,automake,libtool,autoconf,autoconf2.5,zlib-devel,libreadline-devel,libmpc-devel,libmpfr-devel,xdg-open'`
+    - default: `'wget,git,gcc-g++,gcc-core,m4,libgmp-devel,make,automake,libtool,autoconf,autoconf2.5,zlib-devel,libreadline-devel,libmpc-devel,libmpfr-devel,xdg-utils'`
 - `EXTRA_PKGS_TO_INSTALL`:
     - A comma separated list of additional packages to install
     - default: `''`

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   PKGS_TO_INSTALL:
     description: 'the packages to install'
     required: false
-    default: 'wget,git,gcc,gcc-g++,gcc-core,m4,libgmp-devel,make,automake,libtool,autoconf,autoconf2.5,zlib-devel,libreadline-devel,libmpc-devel,libmpfr-devel,xdg-open'
+    default: 'wget,git,gcc-g++,gcc-core,m4,libgmp-devel,make,automake,libtool,autoconf,autoconf2.5,zlib-devel,libreadline-devel,libmpc-devel,libmpfr-devel,xdg-utils'
   EXTRA_PKGS_TO_INSTALL:
     description: 'extra packages to install'
     required: false


### PR DESCRIPTION
gcc doesn't exist (gcc-core gets what we need)
xdg-open is a program, it's contained in xdg-utils