### PR TITLE
Use official Cygwin install action and run bash.exe from batch file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,4 +20,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./
         with:
-          EXTRA_PKGS_TO_INSTALL: ${{ matrix.extra-pkgs }}
+          extra-pkgs-to-install: ${{ matrix.extra-pkgs }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# setup-cygwin
+# setup-cygwin V2
 
 This GitHub action downloads and prepares an instance of cygwin for the use
 with GAP.
@@ -14,11 +14,11 @@ Its behaviour can be customized via the inputs below.
 
 All of the following inputs are optional.
 
-- `PKGS_TO_INSTALL`:
-    - A comma separated list of packages to install
-    - default: `'wget,git,gcc-g++,gcc-core,m4,libgmp-devel,make,automake,libtool,autoconf,autoconf2.5,zlib-devel,libreadline-devel,libmpc-devel,libmpfr-devel,xdg-utils'`
-- `EXTRA_PKGS_TO_INSTALL`:
-    - A comma separated list of additional packages to install
+- `pkgs-to-install`:
+    - Comma-separated list containing the Cygwin packages needed to install GAP
+    - default: `'wget,git,gcc-g++,gcc-core,libgmp-devel,make,libtool,autoconf,zlib-devel,libreadline-devel'`
+- `extra-pkgs-to-install`:
+    - Comma-separated list containing the extra Cygwin packages needed to install additional packages
     - default: `''`
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# setup-cygwin V2
+# setup-cygwin
 
 This GitHub action downloads and prepares an instance of cygwin for the use
 with GAP.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All of the following inputs are optional.
 
 - `pkgs-to-install`:
     - Comma-separated list containing the Cygwin packages needed to install GAP
-    - default: `'wget,git,gcc-g++,gcc-core,libgmp-devel,make,libtool,autoconf,zlib-devel,libreadline-devel'`
+    - default: `'wget,git,gcc-g++,gcc-core,libgmp-devel,make,libtool,autoconf,zlib-devel,libreadline-devel,xdg-utils'`
 - `extra-pkgs-to-install`:
     - Comma-separated list containing the extra Cygwin packages needed to install additional packages
     - default: `''`

--- a/action.yml
+++ b/action.yml
@@ -1,50 +1,45 @@
-name: 'Setup cygwin for a GAP installation'
-description: 'Download and install cygwin such that GAP can be installed afterwards'
+name: 'Setup Cygwin for a GAP installation'
+description: 'Download and install Cygwin such that GAP can be installed afterwards'
 inputs:
-  PKGS_TO_INSTALL:
-    description: 'the packages to install'
+  pkgs-to-install:
+    description: 'Comma-separated list containing the Cygwin packages needed to install GAP'
     required: false
-    default: 'wget,git,gcc-g++,gcc-core,m4,libgmp-devel,make,automake,libtool,autoconf,autoconf2.5,zlib-devel,libreadline-devel,libmpc-devel,libmpfr-devel,xdg-utils'
-  EXTRA_PKGS_TO_INSTALL:
-    description: 'extra packages to install'
+    default: 'wget,git,gcc-g++,gcc-core,libgmp-devel,make,libtool,autoconf,zlib-devel,libreadline-devel'
+  extra-pkgs-to-install:
+    description: 'Comma-separated list containing the extra Cygwin packages needed to install additional packages'
     required: false
     default: ''
+    
 runs:
   using: "composite"
   steps:
-    - name: Download cygwin
-      run: |
-        & cmd /c 'nslookup www.cygwin.com 2>&1'
-        while ($true)
-        {
-            try
-            {
-                (New-Object Net.WebClient).DownloadFile('http://www.cygwin.com/setup-x86_64.exe', 'setup-x86_64.exe')
-                break
-            }
-            catch
-            {
-                Write-Host "There is an error during package downloading:`n $_"
-            }
-        }
-        & cmd /c 'nslookup www.cygwin.com 8.8.8.8 2>&1'
-      shell: powershell
-    - name: Install cygwin
-      run: |
-        @ECHO ON
-        SET CYGROOT=C:\cygwin64
-        SET CYGCACHE=%CYGROOT%\var\cache\setup
-        setup-x86_64.exe -qnNdO -R %CYGROOT% -l %CYGCACHE% -s %CYGMIRROR% -P ${{ inputs.PKGS_TO_INSTALL }},${{ inputs.EXTRA_PKGS_TO_INSTALL }}
-      env:
-        CYGMIRROR: "http://mirror.easyname.at/cygwin"
-      shell: cmd
 
-    - name: Set up cygwin profile
-      run: |
-        C:\cygwin64\bin\bash -l -c bash
+    - name: "Configure git autocrlf to input"
       shell: cmd
+      run: git config --global core.autocrlf input
+
+    - name: "Download and install Cygwin"
+      uses: cygwin/cygwin-install-action@v5
+      with:
+        packages: "${{ inputs.pkgs-to-install}},${{ inputs.extra-pkgs-to-install }}"
+        add-to-path: false
+        install-dir: C:\cygwin64
+
+    - name: "Add bash with correct options to PATH"
+      shell: powershell
+      run: |
+        mkdir C:\cygwin-bash-folder
+        $executable = @"
+        @echo off
+        set CHERE_INVOKING=1
+        for %%a in (%*) do set file=%%a
+        C:\cygwin64\bin\bash.exe --login -e -o pipefail -o igncr %file%
+        exit /b %errorlevel%
+        "@
+        Set-Content C:\cygwin-bash-folder\bash.bat $executable -Encoding utf8 
+        echo "C:\cygwin-bash-folder" >> $env:GITHUB_PATH
     
     # cygwin provides 'make' but not 'gmake', and there is another executable called 'gmake' elsewhere in the windows build.
-    - name: Set up 'gmake' symlink
+    - name: "Set up 'gmake' symlink"
+      shell: bash
       run: ln -s /usr/bin/make /usr/bin/gmake
-      shell: C:\cygwin64\bin\bash.exe --login --norc -o igncr '{0}'

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ inputs:
   pkgs-to-install:
     description: 'Comma-separated list containing the Cygwin packages needed to install GAP'
     required: false
-    default: 'wget,git,gcc-g++,gcc-core,libgmp-devel,make,libtool,autoconf,zlib-devel,libreadline-devel'
+    default: 'wget,git,gcc-g++,gcc-core,libgmp-devel,make,libtool,autoconf,zlib-devel,libreadline-devel,xdg-utils'
   extra-pkgs-to-install:
     description: 'Comma-separated list containing the extra Cygwin packages needed to install additional packages'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         @echo off
         set CHERE_INVOKING=1
         for %%a in (%*) do set file=%%a
-        C:\cygwin64\bin\bash.exe --login -e -o pipefail -o igncr %file%
+        C:\cygwin64\bin\bash.exe --login --norc -e -o pipefail -o igncr %file%
         exit /b %errorlevel%
         "@
         Set-Content C:\cygwin-bash-folder\bash.bat $executable -Encoding utf8 


### PR DESCRIPTION
This is pretty much a complete overhaul. To summarise the changes (more or less in order of importance)

- Cygwin is now installed using the official `cygwin-install-action`.
- A batch file `bash.bat` is created which sets `CHERE_INVOKING` to `1` and runs `bash.exe` with the options `--login -e -o pipefail -o igncr` while ignoring other arguments. That batch file is added to PATH.
- Git is configured with `core.autocrlf input`.
- The default list of packages has been shortened to only include those needed to build and run GAP (I think).
- Inputs are now of the form `input-var` instead of `INPUT_VAR`.

This should allow running other actions with `shell: bash` instead of needing `shell: C:\cygwin64\bin\bash.exe --login --norc -o igncr '{0}'`. Which in turn should mean that separate Cygwin branches for actions are no longer needed.

---

I'm not overly fond of having to use a batch file, but I wasn't able to get this to work otherwise. Some remarks on this:

- Configuring git wasn't enough to fix the whole `crlf` mess. Any multi-line run (i.e. steps with `run | ...`) in the `action.yml` file were still written to a `.sh` with `\r`'s present, causing them to fail when ran from `bash`.
- Putting `igncr` to `SHELLOPTS` worked for the most part, but caused problems when building GAP. Probably related to the following warning found in `cygwin-install-action`'s `README`:

> **Warning:** Putting `igncr` in the `SHELLOPTS` environment variable seems like it should have the same effect, but this can have unintended side-effects (by default, `SHELLOPTS` is a shell variable and moving it to the environment causes **all** shell options to propagate to child shells).

- By default, GitHub runs bash with the options `--noprofile --norc -e -o -pipefail`. It seems to be really necessary to run Cygwin with `--login` present and `--noprofile --norc` *not* present to get it to work properly. 

- The batch script currently ignores all arguments given to bash except the last one, because that is usually (always?) the shell script that bash should run. This, uhh, doesn't feel very safe to me, so if someone has a better solution, I'd really welcome it.

EDIT: most of this stems from trying out the ideas posted in https://github.com/gap-actions/setup-gap/issues/18
