### PR TITLE
Install `automake` by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,12 +4,12 @@ inputs:
   pkgs-to-install:
     description: 'Comma-separated list containing the Cygwin packages needed to install GAP'
     required: false
-    default: 'wget,git,gcc-g++,gcc-core,libgmp-devel,make,libtool,autoconf,zlib-devel,libreadline-devel,xdg-utils'
+    default: 'wget,git,gcc-g++,gcc-core,libgmp-devel,make,libtool,autoconf,zlib-devel,libreadline-devel,xdg-utils,automake'
   extra-pkgs-to-install:
     description: 'Comma-separated list containing the extra Cygwin packages needed to install additional packages'
     required: false
     default: ''
-    
+
 runs:
   using: "composite"
   steps:
@@ -36,7 +36,7 @@ runs:
         C:\cygwin64\bin\bash.exe --login --norc -e -o pipefail -o igncr %file%
         exit /b %errorlevel%
         "@
-        Set-Content C:\cygwin-bash-folder\bash.bat $executable -Encoding utf8 
+        Set-Content C:\cygwin-bash-folder\bash.bat $executable -Encoding utf8
         echo "C:\cygwin-bash-folder" >> $env:GITHUB_PATH
     
     # cygwin provides 'make' but not 'gmake', and there is another executable called 'gmake' elsewhere in the windows build.


### PR DESCRIPTION
I found that `setup-cygwin@v2` didn't work for Digraphs, whereas `@v1` did. See https://github.com/digraphs/Digraphs/pull/799

I tracked this down to `setup-cygwin@v2` removing `automake` as one of the packages installed by default. Of course I could just use the input option `extra-pkgs-to-install` with `automake`, and that's what I'm doing for now to make this work. But I figured I'd at least suggest this PR. If you'd rather not add `automake` back in, I won't be upset!