### PR TITLE
Supply multiple mirrors for Cygwin to download from

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ runs:
         packages: "${{ inputs.pkgs-to-install}},${{ inputs.extra-pkgs-to-install }}"
         add-to-path: false
         install-dir: C:\cygwin64
+        site: |
+          http://mirrors.kernel.org/sourceware/cygwin/
+          https://www.mirrorservice.org/sites/sourceware.org/pub/cygwin/
 
     - name: "Add bash with correct options to PATH"
       shell: powershell


### PR DESCRIPTION
As suggested by @Joseph-Edwards in https://github.com/gap-system/gap/pull/6233#issuecomment-3897431643

This doesn't work perfectly, though, as the Cygwin installer will not always switch to the second mirror if the first one fails. In particular, it is not configured to switch mirrors when it encounters `connection error: 12029`, which is exactly the error that occured after the recent hardware failure at `mirrors.kernel.org`.

Maybe a more robust solution would be something like
```
    - name: "Download and install Cygwin (Mirror 1)"
      uses: cygwin/cygwin-install-action@v6
      continue-on-error: true
      with:
        packages: "${{ inputs.pkgs-to-install}},${{ inputs.extra-pkgs-to-install }}"
        add-to-path: false
        install-dir: C:\cygwin64
        site: [ mirror 1 ]
        
    - name: "Download and install Cygwin (Mirror 2)"
      uses: cygwin/cygwin-install-action@v6
      if: [ only run if previous step failed ]
      with:
        packages: "${{ inputs.pkgs-to-install}},${{ inputs.extra-pkgs-to-install }}"
        add-to-path: false
        install-dir: C:\cygwin64
        site: [ mirror 2 ]
```
But that does make the action more messy...